### PR TITLE
use conventional from-require-import everywhere

### DIFF
--- a/_CoqProject
+++ b/_CoqProject
@@ -1,4 +1,4 @@
--R theories Goedel
+-Q theories Goedel
 
 theories/codeSysPrf.v
 theories/fixPoint.v

--- a/theories/PRrepresentable.v
+++ b/theories/PRrepresentable.v
@@ -10,7 +10,7 @@ From hydras.Ackermann Require Import NNtheory.
 From hydras.Ackermann Require Import primRec.
 From Coqprime Require Import ChineseRem.
 From hydras.Ackermann Require Import expressible.
-From Coq Require Import Lists.List.
+From Coq Require Import List.
 From Coq Require Vector.
 From hydras.Ackermann Require Import ListExt.
 From hydras.Ackermann Require Import cPair.

--- a/theories/codeSysPrf.v
+++ b/theories/codeSysPrf.v
@@ -1,5 +1,5 @@
 From Coq Require Import Ensembles.
-From Coq Require Import Lists.List.
+From Coq Require Import List.
 From hydras.Ackermann Require Import checkPrf.
 From hydras.Ackermann Require Import code.
 From hydras.Ackermann Require Import Languages.
@@ -7,7 +7,7 @@ From hydras.Ackermann Require Import folProp.
 From hydras.Ackermann Require Import folProof.
 From hydras.Ackermann Require Import folLogic3.
 From hydras.Ackermann Require Import folReplace.
-Require Import PRrepresentable.
+From Goedel Require Import PRrepresentable.
 From hydras.Ackermann Require Import expressible.
 From hydras.Ackermann Require Import primRec.
 From Coq Require Import Arith.

--- a/theories/fixPoint.v
+++ b/theories/fixPoint.v
@@ -12,9 +12,9 @@ From hydras.Ackermann Require Import folLogic3.
 From hydras.Ackermann Require Import folReplace.
 From hydras.Ackermann Require Import LNN.
 From hydras.Ackermann Require Import codeNatToTerm.
-Require Import PRrepresentable.
+From Goedel Require Import PRrepresentable.
 From hydras.Ackermann Require Import ListExt.
-From Coq Require Import Lists.List.
+From Coq Require Import List.
 From hydras.Ackermann Require Import NN.
 From hydras.Ackermann Require Import expressible.
 

--- a/theories/goedel1.v
+++ b/theories/goedel1.v
@@ -1,16 +1,15 @@
 From Coq Require Import Ensembles.
-From Coq Require Import Lists.List.
+From Coq Require Import List.
 From Coq Require Import Arith.
 From hydras.Ackermann Require Import folProp.
 From hydras.Ackermann Require Import folProof.
 From hydras.Ackermann Require Import subProp.
 From hydras.Ackermann Require Import ListExt.
-Require Import fixPoint.
-Require Import codeSysPrf.
+From Goedel Require Import fixPoint.
+From Goedel Require Import codeSysPrf.
 From hydras.Ackermann Require Import wConsistent.
 From hydras.Ackermann Require Import NN.
 From hydras.Ackermann Require Import code.
-
 From hydras.Ackermann Require Import checkPrf.
 
 Section Goedel's_1st_Incompleteness.

--- a/theories/goedel2.v
+++ b/theories/goedel2.v
@@ -1,5 +1,5 @@
 From Coq Require Import Ensembles.
-From Coq Require Import Lists.List.
+From Coq Require Import List.
 From Coq Require Import Arith.
 From hydras.Ackermann Require Import folProp.
 From hydras.Ackermann Require Import folProof.
@@ -10,9 +10,9 @@ From hydras.Ackermann Require Import ListExt.
 (*
 Require Import NNtheory.
 *)
-Require Import fixPoint.
+From Goedel Require Import fixPoint.
 From hydras.Ackermann Require Import NN2PA.
-Require Import codeSysPrf.
+From Goedel Require Import codeSysPrf.
 From hydras.Ackermann Require Import PAtheory.
 From hydras.Ackermann Require Import code.
 (*
@@ -21,7 +21,7 @@ Require Import expressible.
 *)
 From hydras.Ackermann Require Import checkPrf.
 From hydras.Ackermann Require Import codeNatToTerm.
-Require Import rosserPA.
+From Goedel Require Import rosserPA.
 
 Section Goedel's_2nd_Incompleteness.
 

--- a/theories/rosser.v
+++ b/theories/rosser.v
@@ -1,5 +1,5 @@
 From Coq Require Import Ensembles.
-From Coq Require Import Lists.List.
+From Coq Require Import List.
 From Coq Require Import Arith.
 From hydras.Ackermann Require Import folProp.
 From hydras.Ackermann Require Import folProof.
@@ -7,11 +7,11 @@ From hydras.Ackermann Require Import folReplace.
 From hydras.Ackermann Require Import folLogic3.
 From hydras.Ackermann Require Import subProp.
 From hydras.Ackermann Require Import ListExt.
-Require Import fixPoint.
-Require Import codeSysPrf.
+From Goedel Require Import fixPoint.
+From Goedel Require Import codeSysPrf.
 From hydras.Ackermann Require Import NNtheory.
 From hydras.Ackermann Require Import code.
-Require Import PRrepresentable.
+From Goedel Require Import PRrepresentable.
 From hydras.Ackermann Require Import expressible.
 From hydras.Ackermann Require Import checkPrf.
 From hydras.Ackermann Require Import codeNatToTerm.

--- a/theories/rosserPA.v
+++ b/theories/rosserPA.v
@@ -1,5 +1,5 @@
 From Coq Require Import Ensembles.
-From Coq Require Import Lists.List.
+From Coq Require Import List.
 From Coq Require Import Arith.
 From hydras.Ackermann Require Import folProp.
 From hydras.Ackermann Require Import folProof.
@@ -9,11 +9,11 @@ From hydras.Ackermann Require Import subProp.
 From hydras.Ackermann Require Import ListExt.
 From hydras.Ackermann Require Import NNtheory.
 From hydras.Ackermann Require Import NN2PA.
-Require Import fixPoint.
-Require Import codeSysPrf.
+From Goedel Require Import fixPoint.
+From Goedel Require Import codeSysPrf.
 From hydras.Ackermann Require Import PAtheory.
 From hydras.Ackermann Require Import code.
-Require Import PRrepresentable.
+From Goedel Require Import PRrepresentable.
 From hydras.Ackermann Require Import expressible.
 From hydras.Ackermann Require Import checkPrf.
 From hydras.Ackermann Require Import codeNatToTerm.


### PR DESCRIPTION
This increases readability, makes the project compatible with jsCoq, and prepares for the separation of `coq-core` from `coq-stdlib`.